### PR TITLE
When selecting maxPrice, the where clause of the select object must b…

### DIFF
--- a/code/Resource/Filter/Price.php
+++ b/code/Resource/Filter/Price.php
@@ -217,7 +217,7 @@ class Mana_Filters_Resource_Filter_Price extends Mage_Catalog_Model_Resource_Eav
             $maxPriceExpr = new Zend_Db_Expr("MAX({$table}.min_price {$additional} {$fix}) AS m_max_price");
         }
 
-        //Mage::helper('mana_filters')->resetProductCollectionWhereClause($select);
+        Mage::helper('mana_filters')->resetProductCollectionWhereClause($select);
         $select->columns(array($maxPriceExpr))->order('m_max_price DESC');
 
         $result  = $connection->fetchOne($select) * $filter->getCurrencyRate();


### PR DESCRIPTION
…e sanitized. Otherwise following SQL error is issued: Unknown column 'e.status' in 'where clause' ('e' is alias for 'catalog_product_index_price' table)
